### PR TITLE
Modified to upgrade to the newest version of cassandra and emodb

### DIFF
--- a/src/main/java/org/codehaus/mojo/cassandra/CqlExecCassandraMojo.java
+++ b/src/main/java/org/codehaus/mojo/cassandra/CqlExecCassandraMojo.java
@@ -7,6 +7,7 @@ import org.apache.cassandra.exceptions.SyntaxException;
 import org.apache.cassandra.thrift.Cassandra.Client;
 import org.apache.cassandra.thrift.Column;
 import org.apache.cassandra.thrift.Compression;
+import org.apache.cassandra.thrift.ConsistencyLevel;
 import org.apache.cassandra.thrift.CqlResult;
 import org.apache.cassandra.thrift.CqlRow;
 import org.apache.cassandra.utils.ByteBufferUtil;
@@ -249,13 +250,13 @@ public class CqlExecCassandraMojo extends AbstractCassandraMojo {
  	      { 
  	          if (StringUtils.isNotBlank(cqlVersion)) { 
  	              getLog().debug("Setting CQL Version: " + cqlVersion);
- 	              client.set_cql_version(cqlVersion); 
+ 	              client.set_cql_version(cqlVersion);
  	          } 
  	  
  	          for (String cql : cqlStatements) { 
  	              if (StringUtils.isNotBlank(cql)){ 
- 	                  getLog().debug("Executing CQL: " + cql); 
- 	                  CqlResult result = client.execute_cql_query(ByteBufferUtil.bytes(cql), Compression.NONE); 
+ 	                  getLog().debug("Executing CQL: " + cql);
+			  CqlResult result = client.execute_cql3_query(ByteBufferUtil.bytes(cql), Compression.NONE, ConsistencyLevel.ALL);
  	                  cqlExecOperationResults.add(new CqlExecOperationResult(result)); 
  	              } 
  	          } 

--- a/src/main/java/org/codehaus/mojo/cassandra/smart/SmartCqlExecCassandraMojo.java
+++ b/src/main/java/org/codehaus/mojo/cassandra/smart/SmartCqlExecCassandraMojo.java
@@ -7,6 +7,7 @@ import org.apache.cassandra.exceptions.SyntaxException;
 import org.apache.cassandra.thrift.Cassandra.Client;
 import org.apache.cassandra.thrift.Column;
 import org.apache.cassandra.thrift.Compression;
+import org.apache.cassandra.thrift.ConsistencyLevel;
 import org.apache.cassandra.thrift.CqlResult;
 import org.apache.cassandra.thrift.CqlRow;
 import org.apache.cassandra.utils.ByteBufferUtil;
@@ -207,13 +208,13 @@ public class SmartCqlExecCassandraMojo extends AbstractCassandraMojo {
  	      { 
  	          if (StringUtils.isNotBlank(cqlVersion)) { 
  	              getLog().debug("Setting CQL Version: " + cqlVersion);
- 	              client.set_cql_version(cqlVersion); 
+                      client.set_cql_version(cqlVersion);
  	          } 
  	  
  	          for (String cql : cqlStatements) { 
  	              if (StringUtils.isNotBlank(cql)){ 
  	                  getLog().debug("Executing CQL: " + cql); 
- 	                  CqlResult result = client.execute_cql_query(ByteBufferUtil.bytes(cql), Compression.NONE); 
+ 	                  CqlResult result = client.execute_cql3_query(ByteBufferUtil.bytes(cql), Compression.NONE, ConsistencyLevel.ALL);
  	                  cqlExecOperationResults.add(new CqlExecOperationResult(result)); 
  	              } 
  	          } 


### PR DESCRIPTION
Modified plugin to use 1.2 compatible cql and to fix api problems. Also changed the default partitioner from Murmer to Random in order to get around problems using the plugin with the new versions of cassandra.

I think we should probably create a new set of configuration parameters for the plugin that switch versions of cassandra if we need to still support 1.1. I don't think 1.2 cql is backwards compatible with 1.1.

Please do not merge this branch until we've had a chance to discuss.
