### PR TITLE
Added ability to configure native_transport_port in yaml config.

### DIFF
--- a/src/main/java/org/codehaus/mojo/cassandra/AbstractCassandraMojo.java
+++ b/src/main/java/org/codehaus/mojo/cassandra/AbstractCassandraMojo.java
@@ -163,6 +163,13 @@ public abstract class AbstractCassandraMojo extends AbstractMojo
     protected int jmxPort;
 
     /**
+     * Port to listen to for native transport.
+     *
+     * @parameter expression="${cassandra.nativeTransportPort}" default-value="9042"
+     */
+    protected int nativeTransportPort;
+
+    /**
      * Address to bind to and tell other Cassandra nodes to connect to. You
      * <strong>must</strong> change this if you want multiple nodes to be able to
      * communicate!
@@ -433,6 +440,7 @@ public abstract class AbstractCassandraMojo extends AbstractMojo
         config.append("storage_port: ").append(storagePort).append("\n");
         config.append("rpc_address: ").append(rpcAddress).append("\n");
         config.append("rpc_port: ").append(rpcPort).append("\n");
+        config.append("native_transport_port: ").append(nativeTransportPort).append("\n");
         if (seeds != null) {
             config.append("seed_provider: ").append("\n");
             config.append("    - class_name: org.apache.cassandra.locator.SimpleSeedProvider").append("\n");


### PR DESCRIPTION
Currently the `native_transport_port` in the Cassandra config yaml is enabled and always set to the default value, 9042.  Because of this only one Cassandra instance can be started using this plugin concurrently.  This update allows the caller to explicitly configure the native transport port and thus run multiple Cassandras if their use case requires.
