### PR TITLE
EMO-7640 upgrade C* to latest 2.2.x version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@ under the License.
 
     <groupId>com.bazaarvoice.maven.plugins</groupId>
     <artifactId>cassandra-maven-plugin</artifactId>
-    <version>2.2.4-6-SNAPSHOT</version>
+    <version>2.2.19-1-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>BV Customized Version of Mojo's Cassandra Maven Plugin</name>
@@ -110,7 +110,7 @@ under the License.
 
     <properties>
         <mavenVersion>2.2.1</mavenVersion>
-        <cassandraVersion>2.2.4</cassandraVersion>
+        <cassandraVersion>2.2.19</cassandraVersion>
         <slf4jVersion>1.7.12</slf4jVersion>
         <log4jVersion>2.1</log4jVersion>
         <commonsLoggingVersion>1.1.1</commonsLoggingVersion>
@@ -123,6 +123,7 @@ under the License.
         <surefirePluginVersion>2.18.1</surefirePluginVersion>
         <dependencyPluginVersion>2.8</dependencyPluginVersion>
         <buildHelperPluginVersion>1.9</buildHelperPluginVersion>
+        <mavenPluginPluginVersion>3.6.0</mavenPluginPluginVersion>
 
         <java.version>1.8</java.version>
     </properties>
@@ -134,6 +135,10 @@ under the License.
                 <artifactId>cassandra-all</artifactId>
                 <version>${cassandraVersion}</version>
                 <exclusions>
+                    <exclusion>
+                        <groupId>net.java.dev.jna</groupId>
+                        <artifactId>jna</artifactId>
+                    </exclusion>
                     <exclusion>
                         <groupId>org.slf4j</groupId>
                         <artifactId>slf4j-log4j12</artifactId>
@@ -155,6 +160,11 @@ under the License.
                         <artifactId>logback-classic</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>net.java.dev.jna</groupId>
+                <artifactId>jna</artifactId>
+                <version>4.1.0</version>
             </dependency>
             <dependency>
                 <groupId>org.yaml</groupId>
@@ -387,6 +397,11 @@ under the License.
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
                 <version>${deployPluginVersion}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <version>${mavenPluginPluginVersion}</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@ under the License.
 
     <groupId>com.bazaarvoice.maven.plugins</groupId>
     <artifactId>cassandra-maven-plugin</artifactId>
-    <version>2.2.19-1-SNAPSHOT</version>
+    <version>2.2.4-6-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>BV Customized Version of Mojo's Cassandra Maven Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -136,10 +136,6 @@ under the License.
                 <version>${cassandraVersion}</version>
                 <exclusions>
                     <exclusion>
-                        <groupId>net.java.dev.jna</groupId>
-                        <artifactId>jna</artifactId>
-                    </exclusion>
-                    <exclusion>
                         <groupId>org.slf4j</groupId>
                         <artifactId>slf4j-log4j12</artifactId>
                     </exclusion>

--- a/src/site/apt/usage.apt.vm
+++ b/src/site/apt/usage.apt.vm
@@ -119,7 +119,7 @@ mvn cassandra:run -Dcassandra.rpcPort=19160 -Dcassandra.jmxPort=17199 -Dcassandr
           <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna</artifactId>
-            <version>3.2.7</version>
+            <version>4.1.0</version>
           </dependency>
         </dependencies>
       </plugin>
@@ -150,7 +150,7 @@ mvn cassandra:run -Dcassandra.rpcPort=19160 -Dcassandra.jmxPort=17199 -Dcassandr
     <dependency>
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna</artifactId>
-      <version>3.2.7</version>
+      <version>4.1.0</version>
     </dependency>
     ...
   </dependencies>
@@ -185,7 +185,7 @@ mvn cassandra:run -Dcassandra.rpcPort=19160 -Dcassandra.jmxPort=17199 -Dcassandr
     <dependency>
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna</artifactId>
-      <version>3.2.7</version>
+      <version>4.1.0</version>
       <scope>test</scope>
     </dependency>
     ...


### PR DESCRIPTION
[JIRA](https://bits.bazaarvoice.com/jira/browse/EMO-7640)

PR contains changes to support Cassandra version upgrade to 2.2.19
