### PR TITLE
PD-189306: maven-cassandra-plugin: migrate to the "main" default GitHub branch

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -4,9 +4,9 @@ metadata:
   name: maven-cassandra-plugin
   description: Cassandra Maven Plugin
   annotations:
-    backstage.io/techdocs-ref: 'url:https://github.com/bazaarvoice/maven-cassandra-plugin/blob/master/README.md'
+    backstage.io/techdocs-ref: 'url:https://github.com/bazaarvoice/maven-cassandra-plugin/blob/main/README.md'
   links:
-    - url: https://github.com/bazaarvoice/maven-cassandra-plugin/blob/master/README.md
+    - url: https://github.com/bazaarvoice/maven-cassandra-plugin/blob/main/README.md
       title: Github docs
       icon: docs
   tags:


### PR DESCRIPTION
## Github Issue #

[PD-189306](https://bazaarvoice.atlassian.net/browse/PD-189306)

## What Are We Doing Here?

Change master branch to main

## How to Test and Verify

1. Check out this PR
2. Check jenkins jobs which are related to this repository

## Risk

### Level 

Low

### Required Testing

Manual

### Risk Summary

Some jenkins jobs can be not working

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
