### PR TITLE
GHE migration cohort PER-1069- DO NOT MERGE UNTIL THIS REPO IS MIGRATED

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*           @bazaarvoice/emodb
+*           @bvengineering/emodb


### PR DESCRIPTION
# :rotating_light: DO NOT MERGE UNTIL THIS REPOSITORY HAS BEEN MIGRATED

This PR contains changes to support the [Github Enterprise migration](https://bazaarvoice.atlassian.net/wiki/spaces/DEV/pages/78995751534/Curalate+GitHub+Migration). It will update, in this code base, references to repositories that are due to be migrated.
Whilst every attempt has been made to cover all cases, each team is responsible for reviewing, updating and approving this PR.

Note: This PR does not handle the following cases:
  * Modifying references to repositories that have been deleted.
  * Modifying references to a repositories old name where it has been renamed.


:warning: **If you do not follow these instructions you may not be able to deploy changes after migration.**

# What you need to do now

## 1. Review and Approve the PR (But do not merge)

Before migration occurs review the PR to ensure that the changes are valid. If not please make any changes to this as soon as possible to ensure continuity to your ability to build and deploy changes.

Once you are happy that the changes are OK, then please approve the PR but do not merge until your repository has been migrated.

## 2. Manually inspect the following files

The migration script detected github slugs that match that of a curalate private repository but could not determine if it was correct to execute the replacement. Please review these files and see if changes are required.

## 3. Wait until your repo has been migrated

Once your repository has been migrated then merge this PR and test your build and deployment

